### PR TITLE
Ignore temporary handler tsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .aws-sam
 samconfig.toml
+tsconfig-only-handler.json
 env.json
 dist/


### PR DESCRIPTION
The `tsconfig-only-handler.json` doesn't seem important to commit to source control given it's built.