### PR TITLE
Fix resulting filename for env.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ So, now on `sam build` command:
 
 ## Use the AWS SAM CLI to build and test locally
 
-Copy `env.json.sample` to `.env.json`:
+Copy `env.json.sample` to `env.json`:
 
 ```sh
 cp -n env.json{.sample,}


### PR DESCRIPTION
This caused a bit of confusion since I usually use the `dotenv` package and name mine `.env`.