### PR TITLE
Reduce build time by skipping npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-writeItemFunction:
 	$(MAKE) HANDLER=src/handlers/write-item.ts build-lambda-common
 
 build-lambda-common:
-	npm install
+	if [ "package.json" -nt "node_modules" ]; then npm install; fi;
 	rm -rf dist
 	echo "{\"extends\": \"./tsconfig.json\", \"include\": [\"${HANDLER}\"] }" > tsconfig-only-handler.json
 	npm run build -- --build tsconfig-only-handler.json


### PR DESCRIPTION
Only run `npm install` if the node_modules dir is missing or older than the package.json file. This runs on every function during a sam build, and skipping this step drastically reduces the build time.