### PR TITLE
Workaround for stdout corruption

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-sam: sam local start-api --env-vars=env.json
+sam: sam local start-api --env-vars=env.json 2>&1 | tr "\r" "\n" #workaround for stdout corruption https://github.com/aws/aws-lambda-runtime-interface-emulator/issues/15#issuecomment-792448261
 tsc: npm run watch


### PR DESCRIPTION
Current version of the container aws-lambda-runtime-interface-emulator has a bug which corrupts the output of sam local debug statements. This implements the workaround suggested in https://github.com/aws/aws-lambda-runtime-interface-emulator/issues/15#issuecomment-792448261